### PR TITLE
Added links to Adamala, Glass talks

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 _site
 .sass-cache
 .jekyll-metadata
+*~

--- a/docs/pasadena.html
+++ b/docs/pasadena.html
@@ -26,8 +26,8 @@ weight: 5
                     <td>9:30</td>
                     <td>Overview presentations:
                       <ul class="list-unstyled">
-                        <li>9:30 John Glass</li>
-                        <li>9:45 Kate Adamala</li>
+                        <li>9:30 John Glass (<a href="https://osf.io/dxrzm/?view_only=0357d148791042e19d496e40afcda25c">PDF</a>)</li>
+                        <li>9:45 Kate Adamala (<a href="https://osf.io/d9bwz/?view_only=0357d148791042e19d496e40afcda25c">PDF</a>)</li>
                         <li>10:00 Richard Murray (<a href="http://www.cds.caltech.edu/~murray/talks/murray_buildacell-pasadena_24Jul17.pdf">PDF</a>)</li>
                         <li>10:15 Eric Wei</li>
                         <li>10:30 Drew Endy</li>


### PR DESCRIPTION
Added links to talks by Kate Adamala and John Glass.  PDFs are stored on OSF.io.